### PR TITLE
Compilation fixes for gcc 4.9.1

### DIFF
--- a/example/benchmark.cpp
+++ b/example/benchmark.cpp
@@ -22,8 +22,6 @@
 
 #include <spdlog/spdlog.h>
 
-//namespace ch = UFO_CHRONO_NAMESPACE;
-
 namespace at = UFO_ATOMIC_NAMESPACE;
 namespace th = UFO_THREAD_NAMESPACE;
 namespace ch = UFO_CHRONO_NAMESPACE;
@@ -129,7 +127,7 @@ private:
     print_alloc_faults()
     {
         std::printf(
-            "%u fixed size queue alloc faults\n",
+            "%lu fixed size queue alloc faults\n",
             m_alloc_faults.load (ufo::mo_relaxed)
             );
     }
@@ -174,7 +172,7 @@ private:
                 (m_cummulative_enqueue_ns.load (ufo::mo_relaxed));
 
         std::printf(
-            "%s using %u threads for a total of %u msgs\n",
+            "%s using %lu threads for a total of %lu msgs\n",
             static_cast<derived&> (*this).get_name_impl(),
             thread_count,
             msgs
@@ -319,14 +317,14 @@ private:
     void create_impl()
     {
         //Fixed queue size of few thousands give best results
-        
+
         m_logger = spdlog::rotating_logger_mt(
                     "rotating_mt_async",
                     OUT_FOLDER "/" "spdlog_async",
                     file_size_bytes,
                     1000
                     );
-        
+
     }
     //--------------------------------------------------------------------------
     void destroy_impl()
@@ -347,7 +345,7 @@ private:
         }
     }
     //--------------------------------------------------------------------------
-    void flush_impl()           { //flush is done automatically} 
+    void flush_impl()           { /* flush is done automatically */ }
     //--------------------------------------------------------------------------
     const char* get_name_impl() { return "spdlog"; }
     //--------------------------------------------------------------------------
@@ -367,7 +365,7 @@ private:
                     file_size_bytes,
                     1000
                     );
-        
+
     }
     //--------------------------------------------------------------------------
     void destroy_impl()
@@ -388,7 +386,7 @@ private:
         }
     }
     //--------------------------------------------------------------------------
-    void flush_impl()           { //flush is done automatically} 
+    void flush_impl()           { /* flush is done automatically */ }
     //--------------------------------------------------------------------------
     const char* get_name_impl() { return "spdlog_sync"; }
     //--------------------------------------------------------------------------
@@ -480,7 +478,7 @@ void spdlog_tests (ufo::uword msgs)
 
     spd_async_tester.run (msgs, 8);
     do_a_pause();
-    
+
     std::printf ("spdlog sync ------------------------------------------\n");
     spd_log_sync_tester spd_sync_tester;
 
@@ -530,6 +528,5 @@ int main (int argc, const char* argv[])
     }
     return 0;
 }
+
 //------------------------------------------------------------------------------
-
-

--- a/example/rotation.cpp
+++ b/example/rotation.cpp
@@ -57,14 +57,14 @@ void rotation_test()
             ((double) msg_count / (double) writer_ns) * 1000000000.;
 
     std::printf(
-            "%u msgs enqueued in %lld ns. %f msgs/sec\n",
+            "%lu msgs enqueued in %ld ns. %f msgs/sec\n",
             msg_count,
             reader_ns,
             reader_msgs_s
             );
 
     std::printf(
-            "%u msgs dispatched in %lld ns. %f msgs/sec\n",
+            "%lu msgs dispatched in %ld ns. %f msgs/sec\n",
             msg_count,
             writer_ns,
             writer_msgs_s

--- a/src/ufo_log/log_files.hpp
+++ b/src/ufo_log/log_files.hpp
@@ -42,6 +42,7 @@ either expressed or implied, of Rafael Gago Castano.
 #include <string>
 #include <deque>
 #include <fstream>
+#include <vector>
 
 #include <ufo_log/util/integer.hpp>
 #include <ufo_log/util/atomic.hpp>
@@ -210,7 +211,7 @@ private:
         str      += sz;
 
         sz        = fixed_chars_in_name;
-        snprintf (str, sz + 1, "%016llx-%016llx", calendar, cpu);
+        snprintf (str, sz + 1, "%016lx-%016lx", calendar, cpu);
         str      += sz;
 
         sz        = suffix.size();

--- a/src/ufo_log/util/thread.hpp
+++ b/src/ufo_log/util/thread.hpp
@@ -46,6 +46,8 @@ either expressed or implied, of Diadrom AB.
 #else
 
 #include <thread>
+#include <condition_variable>
+#include <mutex>
 
 #define UFO_THREAD_NAMESPACE ::std
 


### PR DESCRIPTION
Fixes required to compile without warnings on gcc 4.9.1.  Please excuse my Emacs' habit of removing trailing whitespace.
