### PR TITLE
Fix build with Boost

### DIFF
--- a/src/mal_log/util/queue_backoff.hpp
+++ b/src/mal_log/util/queue_backoff.hpp
@@ -164,12 +164,12 @@ public:
     void wait()
     {
         if (!detail::queue_backoff::wait()) {
-            th::unique_lock<std::mutex> lock (m_mutex);
+            th::unique_lock<th::mutex> lock (m_mutex);
             m_cond.wait_for (lock, ch::nanoseconds (get_sleep_block_ns()));
         }
     }
     //--------------------------------------------------------------------------
-    void wait (th::unique_lock<std::mutex>& lock)
+    void wait (th::unique_lock<th::mutex>& lock)
     {
         if (!detail::queue_backoff::wait()) {
             m_cond.wait_for (lock, ch::nanoseconds (get_sleep_block_ns()));


### PR DESCRIPTION
File currently depends on *std::mutex*, thus fails when *MAL_USE_BOOST_THREAD* is defined